### PR TITLE
Bug fixes and additional debugging commands

### DIFF
--- a/ViridiX.Explorer/App.config
+++ b/ViridiX.Explorer/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
 </configuration>

--- a/ViridiX.Explorer/Properties/Resources.Designer.cs
+++ b/ViridiX.Explorer/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace ViridiX.Explorer.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/ViridiX.Explorer/Properties/Settings.Designer.cs
+++ b/ViridiX.Explorer/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace ViridiX.Explorer.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "14.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.4.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/ViridiX.Explorer/ViridiX.Explorer.csproj
+++ b/ViridiX.Explorer/ViridiX.Explorer.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ViridiX.Explorer</RootNamespace>
     <AssemblyName>ViridiX.Explorer</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>

--- a/ViridiX.Linguist.Tests/ViridiX.Linguist.Tests.csproj
+++ b/ViridiX.Linguist.Tests/ViridiX.Linguist.Tests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ViridiX.Linguist.Tests</RootNamespace>
     <AssemblyName>ViridiX.Linguist.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/ViridiX.Linguist/Network/XboxCommandResponse.cs
+++ b/ViridiX.Linguist/Network/XboxCommandResponse.cs
@@ -1,4 +1,8 @@
 ﻿
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
 namespace ViridiX.Linguist.Network
 {
     /// <summary>

--- a/ViridiX.Linguist/Network/XboxConnection.cs
+++ b/ViridiX.Linguist/Network/XboxConnection.cs
@@ -93,8 +93,8 @@ namespace ViridiX.Linguist.Network
             _logger = logger;
             NoDelay = true;
             JitterThreshold = 3;
-            ReceiveTimeout = 100;
-            SendTimeout = 100;
+            ReceiveTimeout = 500;
+            SendTimeout = 500;
             SendBufferSize = 1024 * 1024 * 10;
             ReceiveBufferSize = 1024 * 1024 * 10;
         }
@@ -303,6 +303,26 @@ namespace ViridiX.Linguist.Network
             }
 
             return text.ToString();
+        }
+
+        public byte[] ReceiveBinary(int timeout = 0)
+        {
+            // Read the size of the binary data.
+            int size = this.Reader.ReadInt32();
+
+            // Sleep until the specified size is available in the socket buffer.
+            Stopwatch timer = Stopwatch.StartNew();
+            while ((timeout == 0 || timer.ElapsedTicks < timeout) && this.Available < size)
+            {
+                Thread.Sleep(10);
+            }
+
+            // Check to see if the specified size is available.
+            if (this.Available < size)
+                throw new InvalidDataException("Expecting more data than was sent");
+
+            // Read the available data.
+            return this.Reader.ReadBytes(size);
         }
 
         /// <summary>

--- a/ViridiX.Linguist/Process/XboxThread.cs
+++ b/ViridiX.Linguist/Process/XboxThread.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using ViridiX.Mason.Utilities;
 
 namespace ViridiX.Linguist.Process
 {
@@ -46,5 +47,31 @@ namespace ViridiX.Linguist.Process
         /// TODO: description
         /// </summary>
         public DateTime CreationTime;
-    };
+    }
+
+    public enum ContextFlags : uint
+    {
+        Control = 1,
+        Integer = 2,
+        FloatingPoint = 8,
+
+        Full = (Control | Integer | FloatingPoint),
+    }
+
+    public class ThreadContext
+    {
+        public ContextFlags Flags;
+        public uint Edi;
+        public uint Esi;
+        public uint Ebx;
+        public uint Edx;
+        public uint Ecx;
+        public uint Eax;
+        public uint Ebp;
+        public uint Eip;
+        public uint Esp;
+        public uint EFlags;
+        public uint SegCs;
+        public uint SegSs;
+    }
 }

--- a/ViridiX.Linguist/ViridiX.Linguist.csproj
+++ b/ViridiX.Linguist/ViridiX.Linguist.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ViridiX.Linguist</RootNamespace>
     <AssemblyName>ViridiX.Linguist</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>

--- a/ViridiX.Linguist/Xbox.cs
+++ b/ViridiX.Linguist/Xbox.cs
@@ -132,7 +132,7 @@ namespace ViridiX.Linguist
             Process = new XboxProcess(this);
             DebugMonitor = new XboxDebugMonitor(this);
             FileSystem = new XboxFileSystem(this);
-            ConnectionId = Process.Call(Kernel.Exports.PhyGetLinkState, 0).ConnectionId;
+            //ConnectionId = Process.Call(Kernel.Exports.PhyGetLinkState, 0).ConnectionId;
             Logger?.Info("All Xbox subsystems have been successfully initialized");
         }
 

--- a/ViridiX.Mason.Tests/ViridiX.Mason.Tests.csproj
+++ b/ViridiX.Mason.Tests/ViridiX.Mason.Tests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ViridiX.Mason.Tests</RootNamespace>
     <AssemblyName>ViridiX.Mason.Tests</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/ViridiX.Mason/Serialization/DataDeserializer.cs
+++ b/ViridiX.Mason/Serialization/DataDeserializer.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ViridiX.Mason.Serialization
+{
+    public class DataDeserializer
+    {
+        public static T DeserializeBlock<T>(BinaryReader reader)
+        {
+            return (T)DeserializeBlock(reader, typeof(T));
+        }
+
+        public static object DeserializeBlock(BinaryReader reader, Type type)
+        {
+            // Create a new instance of the type to populate with data.
+            object value = Activator.CreateInstance(type);
+
+            // Get the field list for the specified type.
+            FieldInfo[] fields = SerializerCache.GetOrCacheTypeInfo(type);
+
+            // Loop and deserialize all fields.
+            for (int i = 0; i < fields.Length; i++)
+            {
+                // Check if this is a primitive or complex type.
+                if (fields[i].FieldType.IsArray == true)
+                {
+                    // Get the field value and check it is not null (arrays must be pre-initialized to get the length).
+                    dynamic fieldValue = fields[i].GetValue(value);
+                    if (fieldValue == null)
+                        throw new InvalidDataException("Arrays must be pre-initialized with compile time constant length");
+
+                    // Loop and deserialize the array.
+                    for (int x = 0; x < fieldValue.Length; x++)
+                    {
+                        // Ahh yes, C# in all it's glory...
+                        dynamic temp = DeserializePrimitiveValue(reader, fields[i].FieldType);
+                        fieldValue[x] = temp;
+                    }
+                }
+                else if (fields[i].FieldType.IsEnum == true)
+                {
+                    // Deserialize enum value.
+                    fields[i].SetValue(value, DeserializePrimitiveValue(reader, Enum.GetUnderlyingType(fields[i].FieldType)));
+                }
+                else if (fields[i].FieldType.IsPrimitive == true)
+                {
+                    // Deserialize primitive value.
+                    fields[i].SetValue(value, DeserializePrimitiveValue(reader, fields[i].FieldType));
+                }
+                else
+                {
+                    // Deserialize complex type.
+                    fields[i].SetValue(value, DeserializeBlock(reader, fields[i].FieldType));
+                }
+            }
+
+            // Return the deserialized field.
+            return value;
+        }
+
+        public static T DeserializePrimitiveValue<T>(BinaryReader reader)
+        {
+            return (T)DeserializePrimitiveValue(reader, typeof(T));
+        }
+
+        public static object DeserializePrimitiveValue(BinaryReader reader, Type type)
+        {
+            // Check the type code of the field and handle accordingly.
+            switch (Type.GetTypeCode(type))
+            {
+                case TypeCode.Byte: return reader.ReadByte();
+                case TypeCode.Char: return reader.ReadChar();
+                case TypeCode.Decimal: return reader.ReadDecimal();
+                case TypeCode.Double: return reader.ReadDouble();
+                case TypeCode.Int16: return reader.ReadInt16();
+                case TypeCode.Int32: return reader.ReadInt32();
+                case TypeCode.Int64: return reader.ReadInt64();
+                case TypeCode.SByte: return reader.ReadSByte();
+                case TypeCode.Single: return reader.ReadSingle();
+                case TypeCode.UInt16: return reader.ReadUInt16();
+                case TypeCode.UInt32: return reader.ReadUInt32();
+                case TypeCode.UInt64: return reader.ReadUInt64();
+                default:
+                    {
+                        // Field type not suppported.
+                        throw new NotSupportedException($"Field type '{Type.GetTypeCode(type)}' not supported");
+                    }
+            }
+        }
+    }
+}

--- a/ViridiX.Mason/Serialization/SerializerCache.cs
+++ b/ViridiX.Mason/Serialization/SerializerCache.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ViridiX.Mason.Serialization
+{
+    public static class SerializerCache
+    {
+        // Cached type info for serialization.
+        private static Dictionary<Type, FieldInfo[]> SerializationTypeCache = new Dictionary<Type, FieldInfo[]>();
+
+        public static FieldInfo[] GetOrCacheTypeInfo(Type type)
+        {
+            // Check if we already have field info cached for the type.
+            if (SerializationTypeCache.ContainsKey(type) == false)
+            {
+                // Get and cache fields for the type.
+                CacheFieldsForType(type);
+            }
+
+            // Return the cache field info.
+            return SerializationTypeCache[type];
+        }
+
+        private static void CacheFieldsForType(Type type)
+        {
+            // Create a list to hold the base type hierarchy temporarily.
+            List<string> baseTypes = new List<string>();
+            baseTypes.Add(type.Name);
+
+            // Build the base type hierarchy.
+            Type baseType = type.BaseType;
+            while (baseType != typeof(object) && baseType != typeof(ValueType))
+            {
+                // Add the base type name to the hierarchy.
+                baseTypes.Add(baseType.Name);
+
+                // Recursively walk base types.
+                baseType = baseType.BaseType;
+            }
+
+            // Loop and create the hierarchy dictionary which is weighted based on the position of the base class in the hierarchy.
+            Dictionary<string, int> baseTypeHierarchy = new Dictionary<string, int>();
+            for (int i = baseTypes.Count - 1; i >= 0; i--)
+                baseTypeHierarchy.Add(baseTypes[i], baseTypeHierarchy.Count);
+
+            // Get a list of all public instance fields in the type.
+            FieldInfo[] fields = type.GetFields(BindingFlags.Public | BindingFlags.Instance);
+
+            // Sort the fields so that they are in the order they are declared in.
+            fields = fields.OrderBy(f => baseTypeHierarchy[f.DeclaringType.Name]).ThenBy(f => f.MetadataToken).ToArray();
+
+            // Add the field info to the cache.
+            SerializationTypeCache[type] = fields;
+        }
+    }
+}

--- a/ViridiX.Mason/Utilities/BitUtilities.cs
+++ b/ViridiX.Mason/Utilities/BitUtilities.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ViridiX.Mason.Utilities
+{
+    public static class BitUtilities
+    {
+        public static void ToBytes(short value, byte[] buffer, int index)
+        {
+            ToBytes(value, 2, buffer, index);
+        }
+
+        public static void ToBytes(ushort value, byte[] buffer, int index)
+        {
+            ToBytes(value, 2, buffer, index);
+        }
+
+        public static void ToBytes(int value, byte[] buffer, int index)
+        {
+            ToBytes(value, 4, buffer, index);
+        }
+
+        public static void ToBytes(uint value, byte[] buffer, int index)
+        {
+            ToBytes(value, 4, buffer, index);
+        }
+
+        public static void ToBytes(float value, byte[] buffer, int index)
+        {
+            ToBytes(value, 4, buffer, index);
+        }
+
+        public static void ToBytes(long value, byte[] buffer, int index)
+        {
+            ToBytes(value, 8, buffer, index);
+        }
+
+        public static void ToBytes(ulong value, byte[] buffer, int index)
+        {
+            ToBytes(value, 8, buffer, index);
+        }
+
+        private static void ToBytes(dynamic value, int count, byte[] buffer, int index)
+        {
+            // Loop for the number of bytes in the value.
+            for (int i = 0; i < count; i++)
+            {
+                // Convert to bytes.
+                buffer[index + i] = (byte)((value >> (i * 8)) & 0xFF);
+            }
+        }
+
+        public static uint ParseUintHexString(string value)
+        {
+            // Remove the hex specifier if it exists as C# still can't handle strings with hex specifiers even when using
+            // the 'AllowHexSpecifier' flag, 2022, what a time to be alive...
+            if (value.StartsWith("0x") == true)
+                return uint.Parse(value.Substring(2), System.Globalization.NumberStyles.HexNumber);
+            else
+                return uint.Parse(value, System.Globalization.NumberStyles.HexNumber);
+        }
+    }
+}

--- a/ViridiX.Mason/Utilities/Tokenizer.cs
+++ b/ViridiX.Mason/Utilities/Tokenizer.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ViridiX.Mason.Utilities
+{
+    public static class Tokenizer
+    {
+        /// <summary>
+        /// Tokenizes a response message that's in a key=value format
+        /// </summary>
+        /// <returns>Dictionary containing key-value pairs</returns>
+        public static Dictionary<string, string> TokenizeResponse(string message)
+        {
+            // Split the string into pieces.
+            string[] pieces = message.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+
+            // Loop and build the tokenized dictionary.
+            Dictionary<string, string> tokenDictionary = new Dictionary<string, string>();
+            for (int i = 0; i < pieces.Length; i++)
+            {
+                // Check if the token as a value associated with it.
+                if (pieces[i].Contains('=') == true)
+                {
+                    // Split the string into key value and add it to the dictionary.
+                    string[] keyValue = pieces[i].Split('=');
+                    tokenDictionary.Add(keyValue[0], keyValue[1]);
+                }
+                else
+                {
+                    // Add the key with no value.
+                    tokenDictionary.Add(pieces[i], "");
+                }
+            }
+
+            // Return the token dictionary.
+            return tokenDictionary;
+        }
+    }
+}

--- a/ViridiX.Mason/ViridiX.Mason.csproj
+++ b/ViridiX.Mason/ViridiX.Mason.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ViridiX.Mason</RootNamespace>
     <AssemblyName>ViridiX.Mason</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
   </PropertyGroup>
@@ -73,8 +73,12 @@
     <Compile Include="Logging\SeriLogger.cs" />
     <Compile Include="Network\BlockingNetworkStream.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Serialization\DataDeserializer.cs" />
+    <Compile Include="Serialization\SerializerCache.cs" />
     <Compile Include="Utilities\Assembler.cs" />
+    <Compile Include="Utilities\BitUtilities.cs" />
     <Compile Include="Utilities\TemporaryPropertyAssignment.cs" />
+    <Compile Include="Utilities\Tokenizer.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/ViridiX.Ventriloquist/App.config
+++ b/ViridiX.Ventriloquist/App.config
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/>
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
 </configuration>

--- a/ViridiX.Ventriloquist/Properties/Resources.Designer.cs
+++ b/ViridiX.Ventriloquist/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace ViridiX.Ventriloquist.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/ViridiX.Ventriloquist/Properties/Settings.Designer.cs
+++ b/ViridiX.Ventriloquist/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace ViridiX.Ventriloquist.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "14.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.4.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/ViridiX.Ventriloquist/ViridiX.Ventriloquist.csproj
+++ b/ViridiX.Ventriloquist/ViridiX.Ventriloquist.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ViridiX.Ventriloquist</RootNamespace>
     <AssemblyName>ViridiX.Ventriloquist</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>

--- a/ViridiX.sln
+++ b/ViridiX.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.25420.1
+# Visual Studio Version 17
+VisualStudioVersion = 17.4.33213.308
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ViridiX.Mason", "ViridiX.Mason\ViridiX.Mason.csproj", "{CD0236F3-7AF3-44CE-A86A-34DA28E48207}"
 EndProject
@@ -48,5 +48,8 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {F5C0B57E-BAD3-4090-9A22-1FD60139E42A}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
This PR adds/fixes the following items:

- Added support for debugging commands (breakpoints, continue, thread context, file transfer).
- Increased send/receive timeout for improved reliability with slow consoles.
- Made remote code execution patches optional for consoles not running v7887 xbdm.
- Updated XboxMemoryStream to closer match Stream API spec.
- Fixed issue with large contiguous reads using getmem2 command.
- Updated target .Net Framework to v4.8.