### PR TITLE
Migrated from packages.json to packge references.

### DIFF
--- a/ViridiX.Mason/ViridiX.Mason.csproj
+++ b/ViridiX.Mason/ViridiX.Mason.csproj
@@ -33,22 +33,6 @@
     <PlatformTarget>x86</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Fasm.NET, Version=1.0.4939.27955, Culture=neutral, processorArchitecture=x86">
-      <HintPath>..\packages\Fasm.NET.1.70.03.2\lib\Fasm.NET.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.2.4.0\lib\net46\Serilog.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Serilog.Sinks.File, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.Sinks.File.3.2.0\lib\net45\Serilog.Sinks.File.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Serilog.Sinks.RollingFile, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
-      <HintPath>..\packages\Serilog.Sinks.RollingFile.3.3.0\lib\net45\Serilog.Sinks.RollingFile.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.configuration" />
     <Reference Include="System.Core" />
@@ -81,9 +65,16 @@
     <Compile Include="Utilities\Tokenizer.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
+    <PackageReference Include="Fasm.NET">
+      <Version>1.70.3.2</Version>
+    </PackageReference>
+    <PackageReference Include="Serilog">
+      <Version>2.4.0</Version>
+    </PackageReference>
+    <PackageReference Include="Serilog.Sinks.RollingFile">
+      <Version>3.3.0</Version>
+    </PackageReference>
   </ItemGroup>
-  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/ViridiX.Mason/packages.config
+++ b/ViridiX.Mason/packages.config
@@ -1,7 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Fasm.NET" version="1.70.03.2" targetFramework="net462" />
-  <package id="Serilog" version="2.4.0" targetFramework="net462" />
-  <package id="Serilog.Sinks.File" version="3.2.0" targetFramework="net452" />
-  <package id="Serilog.Sinks.RollingFile" version="3.3.0" targetFramework="net452" />
-</packages>


### PR DESCRIPTION
Migrated from packages.json to package references which allows ViridiX to be consumed as a git submodule in other projects without having to work around the limitations that come with packages.json configuration.